### PR TITLE
pin python, jupyterlab, nbresuse

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,9 +27,10 @@ dependencies:
   - ipyleaflet
   - ipympl
   - ipywidgets
-  - jupyterlab
+  - jupyterlab=2
   - matplotlib
   - matplotlib-scalebar
+  - nbresuse==0.3.6
   - nbgitpuller
   - nodejs
   - numpy
@@ -39,7 +40,7 @@ dependencies:
   - pillow
   - pip
   - pyproj
-  - python
+  - python=3.8
   - rasterio
   - rasterstats
   - rio-cogeo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-jupyter-resource-usage


### PR DESCRIPTION
 jupyterlab 3.0 is going to be released any day now (https://github.com/jupyterlab/jupyterlab/issues/8038) and it seems like there are lots of changes to extensions

so for now revert to nbreuse instead of jupyter-resource-usage package according to changelog instructions https://github.com/jupyter-server/jupyter-resource-usage/blob/master/CHANGELOG.md#050