### PR TITLE
add packages for jupyterhub

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,6 +27,8 @@ dependencies:
   - ipyleaflet
   - ipympl
   - ipywidgets
+  - jupyterhub-singleuser 
+  - jupyter-server-proxy
   - jupyterlab=2
   - matplotlib
   - matplotlib-scalebar


### PR DESCRIPTION
i think this should remedy the following error using this image for a jupyterhub setup:

```
File "/srv/conda/envs/notebook/lib/python3.8/site-packages/jupyterlab/labhubapp.py", line 12, in <module> raise ImportError('You must have jupyterhub installed for this to work.')
```
