### PR TITLE
linux man pages support

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -8,5 +8,5 @@ jupyter labextension install @jupyter-widgets/jupyterlab-manager \
                              jupyter-matplotlib \
                              jupyter-leaflet \
                              dask-labextension
-# other things                             
-mandb
+# support for linux 'manpages'
+yes | unminimize


### PR DESCRIPTION
as far as I can tell adding this should enable `man` command like `man ls`
https://medium.com/@kazushi/use-man-pages-in-ubuntu-docker-containers-2485a7abf500

@dshean @friedrichknuth , not sure you want to merge this, since it will also change your conda package versions, but you can test with the binder link.